### PR TITLE
Update WMM_EPOCH define

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 WMM_Tinier - Arduino library for calculating geomagnetic variation
 
-  Version 1.0.2 - March 8, 2025
+  Version 1.0.3 - October 25, 2025
 
   By David Armstrong<br>
   https://github.com/DavidArmstrong/WMM_Tinier<br>

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WMM_Tinier
-version=1.0.2
+version=1.0.3
 author=David Armstrong <mamoru.tbreesama@gmail.com>
 maintainer=David Armstrong <mamoru.tbreesama@gmail.com>
 sentence=An adaptation of the miniwinwm/WMM_Tiny code for calculating magnetic variation.

--- a/src/wmm.h
+++ b/src/wmm.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#define WMM_EPOCH		2020.0f
+#define WMM_EPOCH		2025.0f
 
 typedef struct
 {
@@ -21,7 +21,7 @@ void wmm_init(void);
 /**
  * Get the date in WMM format
  *
- * @param year Year in 2 digit format of 21st centuary, i.e. 20 represents 2020
+ * @param year Year in 2 digit format of 21st centuary, i.e. 25 represents 2025
  * @param month Month, 1 to 12
  * @param date Date of month, 1 to 31
  * @return Date in WMM format


### PR DESCRIPTION
Correct WMM_EPOCH define to be 2025.0, which was missed in the update to 2025 coefficients that was previously done.